### PR TITLE
Add initializers to set custom time observer interval

### DIFF
--- a/Classes/ios/VKVideoPlayer.h
+++ b/Classes/ios/VKVideoPlayer.h
@@ -128,8 +128,11 @@ VKVideoPlayerViewDelegate
 @property (nonatomic, assign) CGRect landscapeFrame;
 @property (nonatomic, assign) BOOL forceRotate;
 
+@property (nonatomic, assign) CMTime timeObserverInterval;
 
 - (id)initWithVideoPlayerView:(VKVideoPlayerView*)videoPlayerView;
+- (id)initWithTimeObserverInterval:(CMTime)time;
+- (id)initWithVideoPlayerView:(VKVideoPlayerView*)videoPlayerView andTimeObserverInterval:(CMTime)time;
 
 - (void)seekToLastWatchedDuration;
 - (void)seekToTimeInSecond:(float)sec userAction:(BOOL)isUserAction completionHandler:(void (^)(BOOL finished))completionHandler;

--- a/Classes/ios/VKVideoPlayer.m
+++ b/Classes/ios/VKVideoPlayer.m
@@ -46,7 +46,6 @@ typedef enum {
 @property (nonatomic, strong) id captionTopTimer;
 @property (nonatomic, strong) id captionBottomTimer;
 
-
 @end
 
 
@@ -68,6 +67,26 @@ typedef enum {
     [self initialize];
   }
   return self;
+}
+
+- (id)initWithTimeObserverInterval:(CMTime)time {
+    self = [self init];
+    if (self) {
+        self.view = [[VKVideoPlayerView alloc] init];
+        self.timeObserverInterval = time;
+        [self initialize];
+    }
+    return self;
+}
+
+- (id)initWithVideoPlayerView:(VKVideoPlayerView*)videoPlayerView andTimeObserverInterval:(CMTime)time {
+    self = [super init];
+    if (self) {
+        self.view = videoPlayerView;
+        self.timeObserverInterval = time;
+        [self initialize];
+    }
+    return self;
 }
 
 - (void)dealloc {
@@ -507,7 +526,7 @@ typedef enum {
   if (avPlayer) {
     __weak __typeof(self) weakSelf = self;
     [avPlayer addObserver:self forKeyPath:@"status" options:0 context:nil];
-    self.timeObserver = [avPlayer addPeriodicTimeObserverForInterval:CMTimeMake(1, 1) queue:NULL usingBlock:^(CMTime time){
+    self.timeObserver = [avPlayer addPeriodicTimeObserverForInterval:self.timeObserverInterval queue:NULL usingBlock:^(CMTime time){
       [weakSelf periodicTimeObserver:time];
     }];
     

--- a/Classes/ios/VKVideoPlayer.m
+++ b/Classes/ios/VKVideoPlayer.m
@@ -526,6 +526,10 @@ typedef enum {
   if (avPlayer) {
     __weak __typeof(self) weakSelf = self;
     [avPlayer addObserver:self forKeyPath:@"status" options:0 context:nil];
+    
+    if (!self.timeObserverInterval) {
+        self.timeObserverInterval = CMTimeMake(1, 1);
+    }
     self.timeObserver = [avPlayer addPeriodicTimeObserverForInterval:self.timeObserverInterval queue:NULL usingBlock:^(CMTime time){
       [weakSelf periodicTimeObserver:time];
     }];


### PR DESCRIPTION
Enable the option to decide how often the time observer should listen for the current state of the video playback. This is needed in apps that need to hook into these events to add timed interactivity to videos.