### PR TITLE
Solving compile error problem in Xcode 9.4

### DIFF
--- a/Classes/ios/VKVideoPlayer.m
+++ b/Classes/ios/VKVideoPlayer.m
@@ -1303,6 +1303,7 @@ typedef enum {
     case UIInterfaceOrientationPortraitUpsideDown:
       return 180;
       break;
+    default: return 0; break;
   }
 }
 


### PR DESCRIPTION
Solving compile error problem in Xcode 9.4 because of the switch without default